### PR TITLE
fix: update nguniversal/express-engine token path

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -79,12 +79,12 @@ gulp.task('rollup:fesm', function () {
       external: [
         '@angular/core',
         '@angular/common',
-        '@nguniversal/express-engine/tokens'
+        '@nguniversal/express-engine'
       ],
 
       // Format of generated bundle
       // See "format" in https://rollupjs.org/#core-functionality
-      format: 'es'
+      output: {format: 'es'}
     }))
     .pipe(gulp.dest(distFolder));
 });
@@ -113,27 +113,20 @@ gulp.task('rollup:umd', function () {
       external: [
         '@angular/core',
         '@angular/common',
-        '@nguniversal/express-engine/tokens'
+        '@nguniversal/express-engine'
       ],
-
-      // Format of generated bundle
-      // See "format" in https://rollupjs.org/#core-functionality
-      format: 'umd',
-
-      // Export mode to use
-      // See "exports" in https://rollupjs.org/#danger-zone
-      exports: 'named',
 
       // The name to use for the module for UMD/IIFE bundles
       // (required for bundles with exports)
       // See "name" in https://rollupjs.org/#core-functionality
-      name: 'ngx-device-detector',
-
-      // See "globals" in https://rollupjs.org/#core-functionality
-      globals: {
-        typescript: 'ts'
+      output: {
+        name: 'ngx-device-detector',
+        globals: {
+          typescript: 'ts'
+        },
+        format: 'umd',
+        exports: 'named'
       }
-
     }))
     .pipe(rename('ngx-device-detector.umd.js'))
     .pipe(gulp.dest(distFolder));

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "tslint": "~5.7.0",
     "typescript": "~2.4.2",
     "zone.js": "^0.8.14",
-    "@nguniversal/express-engine": "^5.0.0-beta.5"
+    "@nguniversal/express-engine": "^5.0.0-beta.6"
   },
   "engines": {
     "node": ">=6.0.0"

--- a/src/device-detector.service.ts
+++ b/src/device-detector.service.ts
@@ -1,7 +1,7 @@
 /**
  * Created by ahsanayaz on 08/11/2016.
  */
-import { REQUEST } from '@nguniversal/express-engine/tokens';
+import { REQUEST } from '@nguniversal/express-engine';
 import { PLATFORM_ID, Inject, Injectable, Optional} from '@angular/core';
 import { isPlatformBrowser } from '@angular/common';
 import * as Constants from './device-detector.constants';


### PR DESCRIPTION
- update `@nguniversal/express-engine` to the latest version
- update breaking changes in express-engine for the REQUEST token path
- rollup barked at me to use a different configuration syntax, so i updated that too.