### PR TITLE
fix: allow angular 8 peer dependency

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -26,6 +26,6 @@
   "jsnext:main": "ngx-device-detector.js",
   "typings": "ngx-device-detector.d.ts",
   "peerDependencies": {
-    "@angular/core": "^5.0.0 || ^6.0.0 || ^7.0.0"
+    "@angular/core": ">=5.0.0 <9.0.0"
   }
 }


### PR DESCRIPTION
Angular 8 is coming, so this patch allows the angular 8 peer dependency

Thanks for your work on this library! 😄