### PR TITLE
fix: put license type in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "ngx-device-detector-ws",
   "version": "2.0.5",
+  "license": "MIT",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",


### PR DESCRIPTION
This is really urgent to me. I am only allowed to use specific license types in some projects and have ci tests for licenses.

E.g. https://www.npmjs.com/package/license-ls is returning unknown, because it is missing in the package.json

If it is okay - maybe you can release a new version when merged.
Thanks!